### PR TITLE
Changing aar dependency to be compile only

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,15 @@ or
 yarn add react-native-tor
 ```
 2. Link libs
-- Android: there's nothing to do.
+- Android: open `android/app/build.gradle` and add
+  ```
+  implementation files("../../node_modules/react-native-tor/android/libs/sifir_android.aar")
+  ```
 - iOS:
-```
-cd ios/
-pod install
-```
+  ```
+  cd ios/
+  pod install
+  ```
 
 *iOS Projects note*:
 - iOS 11.1 > only: Support iOS Version is 11.1 and higher (#6)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -127,5 +127,5 @@ dependencies {
   // noinspection GradleDynamicVersion
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation fileTree(include: ['*.aar'], dir: 'libs')
+  compileOnly files('libs/sifir_android.aar')
 }


### PR DESCRIPTION
This fixes an issue with gradle4 when `assembleRelease` throws "Direct local .aar file dependencies are not supported when building an AAR".

Additionally, in a project that __consumes__  `react-native-tor` I had to add 

`    implementation files("../../node_modules/react-native-tor/android/libs/sifir_android.aar")`

in `android/app/build.gradle`


AFAIK, none of that is necessary if gradle3 is used to assemble your react native  app.

Reference:

https://stackoverflow.com/questions/16682847/how-to-manually-include-external-aar-package-using-new-gradle-android-build-syst/23326397
https://stackoverflow.com/questions/60878599/error-building-android-library-direct-local-aar-file-dependencies-are-not-supp/63665094
https://github.com/transistorsoft/react-native-background-geolocation/issues/1077



I hope this PR doesn't break anything. 
If merged Ill also submit a change to README file explaining all that gradle4 nuances.


Related: https://github.com/BlueWallet/BlueWallet/pull/2295