### PR TITLE
Fix support for new architecture (interop layer)

### DIFF
--- a/ios/Tor.m
+++ b/ios/Tor.m
@@ -15,12 +15,6 @@ RCT_EXTERN_METHOD(
                   )
 
 RCT_EXTERN_METHOD(
-                  getOnionUrl:(NSString*)url
-                  resolver:(RCTPromiseResolveBlock)resolve
-                  rejecter: (RCTPromiseRejectBlock)reject
-                  )
-
-RCT_EXTERN_METHOD(
                   getDaemonStatus:(RCTPromiseResolveBlock)resolve
                   rejecter: (RCTPromiseRejectBlock)reject
                   )


### PR DESCRIPTION
Hi, there's a module function `getOnionUrl()` being declared that doesn't actually exist.
This is causing a crash on new arch + bridgeless for iOS, as the new arch interop layer tries to expose this function.

This pull request removes that.

To be clear: anyone trying to use this lib in new arch needs this patch.

As this library is kinda dead, you can use my fork in your package.json:

```json
"react-native-tor": "github:hsjoberg/react-native-tor#938d80f798111ee790033d8f46dfdc92795c4766",
```